### PR TITLE
Add linuxu targets

### DIFF
--- a/kraft.yaml
+++ b/kraft.yaml
@@ -9,4 +9,6 @@ targets:
   - architecture: x86_64
     platform: xen
   - architecture: arm64
+    platform: linuxu
+  - architecture: arm64
     platform: kvm

--- a/kraft.yaml
+++ b/kraft.yaml
@@ -12,3 +12,5 @@ targets:
     platform: linuxu
   - architecture: arm64
     platform: kvm
+  - architecture: arm
+    platform: linuxu


### PR DESCRIPTION
This PR series adds two supported targets to the helloworld application:

 - `linuxu-arm`; and,
 - `linuxu-arm64`.