### PR TITLE
Fix dependency for nanosleep()

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -13,7 +13,7 @@ config APPHELLOWORLD_PRINTARGS
 
 config APPHELLOWORLD_SPINNER
 	bool "Stay alive"
-	select LIBUKTIME
+	select LIBPOSIX_TIME
 	default n
 	help
 	  Shows an animation instead of shutting down


### PR DESCRIPTION
In 2ac3bb9a unikraft renamed LIBUKTIME to LIBPOSIX_TIME. Update the dependency of STAY_ALIVE accordingly.

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>