### PR TITLE
Fix verbose build issue by modifying makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@ UK_ROOT ?= $(PWD)/../../unikraft
 UK_LIBS ?= $(PWD)/../../libs
 LIBS :=
 
+# Set the default verbosity level to silent
+MAKEFLAGS += -s
+
+# Override the default verbosity level if V is defined
+ifeq ($(V),1)
+	MAKEFLAGS :=
+endif
+
 all:
 	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)
 


### PR DESCRIPTION
Couldn't find the template, so i wrote this - 
Prerequisite checklist:
[x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
[x] Tested your changes against relevant architectures and platforms;
[x] Ran the [checkpatch.pl](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
[ ]Updated relevant documentation.

Base target:
Architecture(s): N/A
Platform(s): [N/A]
Application(s): N/A

Additional configuration:
N/A

Description of  changes:
The verbosity option wasn't working as addressed in issue [#676.](https://github.com/unikraft/unikraft/issues/676) When setting V=0, the verbose output used to turn up (supposed to turn up only when V=1) , so I made some changes to the Makefile and tested it on different applications and architectures. I initially tried to make changes on the unikraft makefile but that doesn't seem to work, so I think we might have to add these lines (shown in the image) in all the application's makefiles to deal with the verbosity. 
@nderjung 

![1](https://user-images.githubusercontent.com/73271591/229311779-3e9ac914-694f-45a9-9501-abde2dad0dae.png)
