### PR TITLE
Update platform name according to 0.13 release

### DIFF
--- a/kraft.yaml
+++ b/kraft.yaml
@@ -7,12 +7,14 @@ targets:
   - architecture: x86_64
     platform: linuxu
   - architecture: x86_64
-    platform: kvm
+    platform: qemu
+  - architecture: x86_64
+    platform: firecracker
   - architecture: x86_64
     platform: xen
   - architecture: arm64
     platform: linuxu
   - architecture: arm64
-    platform: kvm
+    platform: qemu
   - architecture: arm
     platform: linuxu


### PR DESCRIPTION
v0.13 release introduced an image split between QEMU and Firecracker.