### PR TITLE
Makefile: Remove lwip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 UK_ROOT ?= $(PWD)/workdir/unikraft
 UK_LIBS ?= $(PWD)/workdir/libs
 UK_BUILD ?= $(PWD)/workdir/build
-LIBS := $(UK_LIBS)/lwip
+LIBS :=
 
 all:
 	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS) O=$(UK_BUILD)


### PR DESCRIPTION
The `lwip` library is not required for `helloworld`. Remove it from `Makefile`.